### PR TITLE
Add long options

### DIFF
--- a/src/renderfall.c
+++ b/src/renderfall.c
@@ -64,12 +64,12 @@ void usage(char *arg) {
     fprintf(stderr, "Usage: %s [OPTIONS] <in>\n", arg);
     fprintf(stderr, "Render a waterfall spectrum from raw IQ samples.\n\n");
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  -n <fftsize>\tFFT size (power of 2)\n");
-    fprintf(stderr, "  -f <format>\tInput format: uint8, int16, float64, etc.\n");
-    fprintf(stderr, "  -w <window>\tWindowing function: hann, gaussian, square\n");
-    fprintf(stderr, "  -o <outfile>\tOutput file path (defaults to <infile>.png)\n");
-    fprintf(stderr, "  -s <offset>\tStart at specified byte offset\n");
-    fprintf(stderr, "  -v \t\tPrint verbose debugging output\n");
+    fprintf(stderr, "  -n, --fftsize <fftsize>\tFFT size (power of 2)\n");
+    fprintf(stderr, "  -f, --format <format>\tInput format: uint8, int16, float64, etc.\n");
+    fprintf(stderr, "  -w, --window <window>\tWindowing function: hann, gaussian, square\n");
+    fprintf(stderr, "  -o, --outfile <outfile>\tOutput file path (defaults to <infile>.png)\n");
+    fprintf(stderr, "  -s, --offset  <offset>\tStart at specified byte offset\n");
+    fprintf(stderr, "  -v, --verbose \t\tPrint verbose debugging output\n");
 }
 
 int parse_format(format_t *result, char *arg) {
@@ -122,13 +122,33 @@ int main(int argc, char *argv[]) {
     // Default args.
     format_t fmt = FORMAT_FLOAT32;
     uint32_t fftsize = 2048;
-    bool verbose = false;
+    static int verbose = 0;
     uint64_t skip = 0;
 
     int c;
+    static struct option long_options[] =
+    {
+        /*These options set a flag.*/
+        {"verbose", no_argument,       &verbose, 1},
+        {"brief",   no_argument,       &verbose, 0},
+        /*These options don’t set a flag.*/
+        /*We distinguish them by their indices.*/
+        {"help",      no_argument,      NULL, 'h'},
+        {"fftsize",  required_argument, NULL, 'n'},
+        {"format",   required_argument, NULL, 'f'},
+        {"window",   required_argument, NULL, 'w'},
+        {"outfile",  required_argument, NULL, 'o'},
+        {"offset",   required_argument, NULL, 's'},
+        {0, 0, 0, 0}
 
-    while ((c = getopt(argc, argv, "hvf:n:o:s:")) != -1) {
+    };
+
+    int option_index;
+    while ((c = getopt_long(argc, argv, "hvf:n:o:s:", long_options,&option_index )) != -1) {
         switch (c) {
+            case 0:
+                //Flag option
+                break;
             case 'h':
                 usage(argv[0]);
                 return EXIT_SUCCESS;


### PR DESCRIPTION
I switched verbose to be an int to avoid a compiler warning, not sure if there's a better way to handle that.
